### PR TITLE
Print relative speed up in benchmarks

### DIFF
--- a/atomic-counter.cabal
+++ b/atomic-counter.cabal
@@ -125,8 +125,8 @@ benchmark bench
     , base >= 4.14
     , primitive
     , stm
-    , tasty
-    , tasty-bench
+    , tasty >= 1.4.2
+    , tasty-bench >= 0.3.2
     , tasty-quickcheck
     , test-utils
   ghc-options:


### PR DESCRIPTION
Looks like this:
```
All
  Correctness:          OK (6.04s)
    +++ OK, passed 10000 tests.
  Read/write contention with 10 iterations and 1 threads
    Counter:            OK (3.05s)
      16.1 μs ± 678 ns
    IORef inconsistent: OK (0.95s)
      18.5 μs ± 962 ns, 1.15x
    IORef atomic:       OK (1.06s)
      20.9 μs ± 909 ns, 1.30x
    MVar:               OK (2.07s)
      19.9 μs ± 417 ns, 1.24x
    TMVar:              OK (0.31s)
      24.7 μs ± 1.8 μs, 1.54x
    TVar:               OK (0.28s)
      22.0 μs ± 1.7 μs, 1.37x
    Addr:               OK (3.69s)
      19.5 μs ± 905 ns, 1.21x
```