### PR TITLE
Implement Control.Concurrent.Counter.Unlifted in CMM

### DIFF
--- a/.github/workflows/haskell-ci.yaml
+++ b/.github/workflows/haskell-ci.yaml
@@ -48,6 +48,7 @@ jobs:
         cd atomic-counter-*/
         cabal build all --enable-tests
         cabal test --enable-tests --test-show-details=direct all
+        cabal bench --enable-benchmarks --benchmark-options='--stdev 100 --timeout 100' all
     - name: Haddock
       run: |
         cd atomic-counter-*/

--- a/Counter.cmm
+++ b/Counter.cmm
@@ -1,0 +1,96 @@
+#include "Cmm.h"
+
+INFO_TABLE(stg_Counter, 0, 1, MUT_PRIM, "Counter", "Counter") ()
+{
+  foreign "C" barf("stg_Counter entered!", NULL) never returns;
+}
+
+stg_newCounterzh (W_ x)
+{
+  P_ c;
+  ("ptr" c) = ccall allocate(MyCapability() "ptr", BYTES_TO_WDS(SIZEOF_StgHeader + WDS(1)));
+  SET_HDR(c, stg_Counter_info, CCCS);
+  W_[c + SIZEOF_StgHeader] = x;
+  return (c);
+}
+
+stg_atomicGetCounterzh (P_ c)
+{
+  W_ x;
+  // load_seqcst64 is available since GHC 9.4
+  (x) = prim %load_seqcst64(c + SIZEOF_StgHeader);
+  return (x);
+}
+
+stg_atomicSetCounterzh (P_ c, W_ x)
+{
+  // store_seqcst64 is available since GHC 9.4
+  prim %store_seqcst64(c + SIZEOF_StgHeader, x);
+  return ();
+}
+
+stg_atomicAddCounterzh (P_ c, W_ x)
+{
+  W_ y;
+#if __GLASGOW_HASKELL__ >= 907
+  (y) = prim %fetch_add64(c + SIZEOF_StgHeader, x);
+#else
+  (y) = ccall hs_atomic_add64(c + SIZEOF_StgHeader, x);
+#endif
+  return (y);
+}
+
+stg_atomicSubCounterzh (P_ c, W_ x)
+{
+  W_ y;
+#if __GLASGOW_HASKELL__ >= 907
+  (y) = prim %fetch_sub64(c + SIZEOF_StgHeader, x);
+#else
+  (y) = ccall hs_atomic_sub64(c + SIZEOF_StgHeader, x);
+#endif
+  return (y);
+}
+
+stg_atomicAndCounterzh (P_ c, W_ x)
+{
+  W_ y;
+#if __GLASGOW_HASKELL__ >= 907
+  (y) = prim %fetch_and64(c + SIZEOF_StgHeader, x);
+#else
+  (y) = ccall hs_atomic_and64(c + SIZEOF_StgHeader, x);
+#endif
+  return (y);
+}
+
+stg_atomicOrCounterzh (P_ c, W_ x)
+{
+  W_ y;
+#if __GLASGOW_HASKELL__ >= 907
+  (y) = prim %fetch_or64(c + SIZEOF_StgHeader, x);
+#else
+  (y) = ccall hs_atomic_or64(c + SIZEOF_StgHeader, x);
+#endif
+  return (y);
+}
+
+stg_atomicXorCounterzh (P_ c, W_ x)
+{
+  W_ y;
+#if __GLASGOW_HASKELL__ >= 907
+  (y) = prim %fetch_xor64(c + SIZEOF_StgHeader, x);
+#else
+  (y) = ccall hs_atomic_xor64(c + SIZEOF_StgHeader, x);
+#endif
+  return (y);
+}
+
+stg_atomicNandCounterzh (P_ c, W_ x)
+{
+  W_ y;
+#if __GLASGOW_HASKELL__ >= 907
+  (y) = prim %fetch_nand64(c + SIZEOF_StgHeader, x);
+#else
+  (y) = ccall hs_atomic_nand64(c + SIZEOF_StgHeader, x);
+#endif
+  return (y);
+}

--- a/atomic-counter.cabal
+++ b/atomic-counter.cabal
@@ -78,6 +78,10 @@ library
     src
   build-depends:
     , base >= 4.14 && < 5
+  if impl(ghc >= 9.4) && !arch(javascript)
+    cmm-sources: Counter.cmm
+    ghc-options: -dcmm-lint
+    cpp-options: -DUSE_CMM
 
 library test-utils
   import: ghc-options

--- a/src/Control/Concurrent/Counter/Lifted/ST.hs
+++ b/src/Control/Concurrent/Counter/Lifted/ST.hs
@@ -75,7 +75,7 @@ set
   -> Int
   -> ST s ()
 set (Counter c) (I# x) = ST $ \s1 -> case Unlifted.set c x s1 of
-  s2 -> (# s2, () #)
+  (# s2 #) -> (# s2, () #)
 
 
 {-# INLINE add #-}


### PR DESCRIPTION
Just an experiment to avoid any overhead for `MutableByteArray` inspired by @TerrorJack's https://gist.github.com/TerrorJack/4a48ed790155cc79619fffe9f5844521.

Caveats:

* ~~Does not work in GHC JavaScript backend, which should probably retain the previous, pure Haskell implementation.~~

* Needs more care on 32-bit machines, current code is 64 bit only.

* `ccall hs_atomic_add64` is suboptimal on `x86_64`, but at the moment hand-written CMM cannot access `call MO_AtomicRMW W64 AMO_Add`, see https://gitlab.haskell.org/ghc/ghc/-/issues/23206.