### PR TITLE
Enforce single-threaded execution of benchmarks

### DIFF
--- a/atomic-counter.cabal
+++ b/atomic-counter.cabal
@@ -144,7 +144,7 @@ benchmark bench
     , primitive
     , stm
     , tasty >= 1.4.2
-    , tasty-bench >= 0.3.2
+    , tasty-bench >= 0.3.4
     , tasty-quickcheck
     , test-utils
   ghc-options:

--- a/bench/BenchMain.hs
+++ b/bench/BenchMain.hs
@@ -24,11 +24,10 @@ import Data.Semigroup
 import GHC.Exts
 import GHC.IO
 import Test.QuickCheck
-import Test.Tasty
+import Test.Tasty hiding (defaultMain)
 import Test.Tasty.Bench
 import Test.Tasty.Patterns.Printer
 import Test.Tasty.QuickCheck qualified as QC
-import Test.Tasty.Runners qualified as Tasty
 
 import Control.Concurrent.Counter.Lifted.IO qualified as C
 
@@ -140,10 +139,7 @@ main = do
         , n <- [Iterations 10, Iterations 100, Iterations 1000, Iterations 10000]
         ]
 
-  defaultMainWithIngredients benchIngredients $
-    localOption (Tasty.NumThreads 1) $
-      testGroup "All" $
-      tests ++ benchmarks
+  defaultMain $ tests ++ benchmarks
 
 counterBenchName :: String
 counterBenchName = "Counter"


### PR DESCRIPTION
AFAIR how `tasty` works, `localOption (Tasty.NumThreads 1)` has no effect.